### PR TITLE
remove jQuery

### DIFF
--- a/www/js/app/uiWebAppInstall.js
+++ b/www/js/app/uiWebAppInstall.js
@@ -14,6 +14,7 @@ define(function (require) {
         //Make sure DOM is ready before modifying it.
         $(function () {
             var dom = $('body'),
+                $install = $(install),
                 installDom = dom.find('.webapp-install'),
                 installedDom = dom.find('.webapp-installed'),
                 errorDom = dom.find('.webapp-error');
@@ -57,12 +58,12 @@ define(function (require) {
         });
     }
 
-    install.on('change', onInstallStateChange);
+    $install.on('change', onInstallStateChange);
 
     //Call it now, check the current state.
     onInstallStateChange();
 
-    install.on('error', function (evt, err) {
+    $install.on('error', function (evt, err) {
         //Make sure DOM is ready before modifying it.
         $(function () {
             var errorDom = $('body').find('.webapp-error');
@@ -73,7 +74,7 @@ define(function (require) {
         });
     });
 
-    install.on('showiOSInstall', function (evt, deviceType) {
+    $install.on('showiOSInstall', function (evt, deviceType) {
         //Show the UI that tells the user what Safari
         //button to hit
         $('body').find('.ios').show(0, function () { $(this).addClass(deviceType); });

--- a/www/js/lib/install.js
+++ b/www/js/lib/install.js
@@ -153,8 +153,8 @@ define(function (require) {
     }
 
     function triggerEvent(evtType, detail) {
-        var event = document.createEvent('Event');
-        event.initEvent(evtType, false, false, { detail: detail});
+        var event = document.createEvent('CustomEvent');
+        event.initCustomEvent(evtType, false, false, detail);
         dispatchEvent(event);
     }
 

--- a/www/js/lib/install.js
+++ b/www/js/lib/install.js
@@ -1,19 +1,8 @@
 /*jslint nomen: true */
-/*global define, navigator, location, window, chrome */
+/*global define, navigator, location, window, chrome, document */
 
 define(function (require) {
     'use strict';
-
-    var $ = require('jquery'),
-        dispatcher = $({}),
-        prop;
-
-    //Create event functions based on dispatcher object
-    function createDispatchFn(id) {
-        return function () {
-            return dispatcher[id].apply(dispatcher, arguments);
-        };
-    }
 
     /**
      * Detects if the current app has been installed.
@@ -27,13 +16,13 @@ define(function (require) {
         if (fn) {
             fn();
         } else {
-            install.trigger('error', 'unsupported install: ' + install.type);
+            triggerEvent('error', 'unsupported install: ' + install.type);
         }
     }
 
     function triggerChange(state) {
         install.state = state;
-        install.trigger('change', install.state);
+        triggerEvent('change', install.state);
     }
 
     /**
@@ -120,13 +109,59 @@ define(function (require) {
     //element mentioning how to install using the Safari
     //"Add to Home Screen" button.
     install.iosInstall = function () {
-        install.trigger('showiOSInstall', navigator.platform.toLowerCase());
+        triggerEvent('showiOSInstall', navigator.platform.toLowerCase());
     };
 
+    var listeners = {};
+
+    function addEventListener(type, func /*, don't use capture */) {
+        if (! func) {
+            throw new TypeError('The listener must not be null or undefined.');
+        }
+
+        var theseListeners = listeners[type] = listeners[type] || [];
+        if (theseListeners.indexOf(func) === -1) {
+            theseListeners.push(func);
+        }
+    }
+
+    function removeEventListener(type, func) {
+        var theseListeners = listeners[type];
+        if (theseListeners) {
+            var index = theseListeners.indexOf(func);
+            theseListeners.splice(index, 1);
+        }
+    }
+
+    function dispatchEvent(evt) {
+        var type = evt.type;
+        var theseListeners = listeners[type];
+
+        if (theseListeners) {
+            theseListeners.forEach(function(oneListener) {
+                window.setTimeout(dispatchOneEvent.bind(null, evt, oneListener));
+            });
+        }
+    }
+
+    function dispatchOneEvent(evt, oneListener) {
+        if (typeof oneListener === "function") {
+            oneListener(evt);
+        } else if (typeof oneListener.handleEvent === "function") {
+            oneListener.handleEvent(evt);
+        }
+    }
+
+    function triggerEvent(evtType, detail) {
+        var event = document.createEvent('Event');
+        event.initEvent(evtType, false, false, { detail: detail});
+        dispatchEvent(event);
+    }
+
     //Allow install to do events.
-    install.on = createDispatchFn('on');
-    install.off = createDispatchFn('off');
-    install.trigger = createDispatchFn('trigger');
+    install.addEventListener = addEventListener;
+    install.removeEventListener = removeEventListener;
+    install.dispatchEvent = dispatchEvent;
 
 
     //Start up the checks


### PR DESCRIPTION
This implements a DOM-like event system so that we'd still can
use jQuery on the install object.

This need to be verified though.

I didn't actually try to use this so I'm pretty sure this won't be perfect ;) Still this is jshint-error free. The only thing I really don't know is if jQuery will accept to listen on events on this object that is not a Node even if it implements `addEventListener` and other such functions.

As a side node, I'm not sure we should expose dispatchEvent too.
